### PR TITLE
jtwig-spring: Add global "beans" object for resolving spring beans by name

### DIFF
--- a/jtwig-spring-test/src/main/java/com/lyncode/jtwig/beans/TestService.java
+++ b/jtwig-spring-test/src/main/java/com/lyncode/jtwig/beans/TestService.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.beans;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: Vitali Carbivnicii
+ * Date: 2014-03-20
+ * Time: 18:54
+ */
+@Service("testservice")
+public class TestService {
+
+    public String test(){
+        return "TEST";
+    }
+
+}

--- a/jtwig-spring-test/src/main/java/com/lyncode/jtwig/beans/TestService2.java
+++ b/jtwig-spring-test/src/main/java/com/lyncode/jtwig/beans/TestService2.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.beans;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: Vitali Carbivnicii
+ * Date: 2014-03-20
+ * Time: 18:54
+ */
+@Service("testservice2")
+public class TestService2 {
+
+    public String test(){
+        return "TEST2";
+    }
+
+}

--- a/jtwig-spring-test/src/main/java/com/lyncode/jtwig/spring/WebappConfig.java
+++ b/jtwig-spring-test/src/main/java/com/lyncode/jtwig/spring/WebappConfig.java
@@ -16,6 +16,7 @@
 
 package com.lyncode.jtwig.spring;
 
+import com.lyncode.jtwig.beans.TestService2;
 import com.lyncode.jtwig.controller.DynamicController;
 import com.lyncode.jtwig.functions.test.SimpleJtwigFunction;
 import com.lyncode.jtwig.mvc.JtwigViewResolver;
@@ -24,6 +25,7 @@ import com.lyncode.jtwig.services.api.ViewShownResolver;
 import com.lyncode.jtwig.services.api.assets.AssetResolver;
 import com.lyncode.jtwig.services.impl.InMemoryMessageSource;
 import com.lyncode.jtwig.services.impl.TestModelMapFiller;
+import com.lyncode.jtwig.beans.TestService;
 import com.lyncode.jtwig.services.impl.TestViewShownResolver;
 import com.lyncode.jtwig.services.impl.assets.BaseAssetResolver;
 import org.springframework.context.MessageSource;
@@ -40,7 +42,7 @@ import org.springframework.web.servlet.i18n.FixedLocaleResolver;
 import static java.util.Locale.ENGLISH;
 
 @Configuration
-@ComponentScan(basePackageClasses = { DynamicController.class })
+@ComponentScan(basePackageClasses = { DynamicController.class, TestService.class, TestService2.class })
 @EnableWebMvc
 public class WebappConfig extends WebMvcConfigurerAdapter {
     @Bean

--- a/jtwig-spring-test/src/main/webapp/WEB-INF/views/default/beans/beans.twig.html
+++ b/jtwig-spring-test/src/main/webapp/WEB-INF/views/default/beans/beans.twig.html
@@ -1,0 +1,1 @@
+{{ beans.testservice.test }}-{{ beans.testservice2.test }}

--- a/jtwig-spring-test/src/test/java/com/lyncode/acceptance/beans/BeansResolutionTest.java
+++ b/jtwig-spring-test/src/test/java/com/lyncode/acceptance/beans/BeansResolutionTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2012 Lyncode
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.acceptance.beans;
+
+import com.lyncode.acceptance.AbstractViewTest;
+import com.lyncode.jtwig.services.api.ModelMapFiller;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class BeansResolutionTest extends AbstractViewTest {
+    @Override
+    protected void given(ModelMapFiller modelMap) {
+        // Nothing
+    }
+
+    @Override
+    protected String forView() {
+        return "beans/beans";
+    }
+
+    @Override
+    protected Matcher<? super String> contentMatcher() {
+        return equalTo("TEST-TEST2");
+    }
+}

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/beans/BeanResolver.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/beans/BeanResolver.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.beans;
+
+import org.springframework.context.ApplicationContext;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: Vitali Carbivnicii
+ * Date: 2014-03-20
+ * Time: 19:05
+ */
+public class BeanResolver implements Map {
+
+    private ApplicationContext context;
+
+    public BeanResolver(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public int size() {
+        return context.getBeanDefinitionCount();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return context.getBeanDefinitionCount() == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return context.containsBean((String) key);
+    }
+
+    @Override
+    public Object get(Object key) {
+        return context.getBean((String) key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Object remove(Object key) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void putAll(Map m) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void clear() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Set keySet() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Collection values() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Set<Entry> entrySet() {
+        throw new NotImplementedException();
+    }
+}

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
@@ -19,6 +19,7 @@ package com.lyncode.jtwig.mvc;
 import com.lyncode.jtwig.JtwigContext;
 import com.lyncode.jtwig.JtwigModelMap;
 import com.lyncode.jtwig.JtwigTemplate;
+import com.lyncode.jtwig.beans.BeanResolver;
 import com.lyncode.jtwig.exception.CompileException;
 import com.lyncode.jtwig.exception.ParseException;
 import com.lyncode.jtwig.resource.WebJtwigResource;
@@ -45,6 +46,7 @@ public class JtwigView extends AbstractTemplateView {
     protected String getEncoding() {
         return getViewResolver().getEncoding();
     }
+
     protected String getTheme() {
         return getViewResolver().getTheme();
     }
@@ -64,26 +66,24 @@ public class JtwigView extends AbstractTemplateView {
     }
 
     @Override
-    protected void renderMergedTemplateModel(Map<String, Object> model,
-                                             HttpServletRequest request, HttpServletResponse response)
-            throws Exception {
+    protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
 
         // Adding model information
         JtwigModelMap modelMap = new JtwigModelMap()
                 .add(model)
+                .add("beans", new BeanResolver(getApplicationContext()))
                 .add("theme", getTheme())
-                .add("request", request)
-            ;
+                .add("request", request);
 
         if (log.isDebugEnabled()) {
             log.debug("Rendering Jtwig template [" + getUrl() + "] in JtwigView '" + getBeanName() + "'");
-            log.debug("Model: "+modelMap);
+            log.debug("Model: " + modelMap);
         }
 
-
         response.setContentType(this.getContentType());
-        if (this.getEncoding() != null)
+        if (this.getEncoding() != null){
             response.setCharacterEncoding(this.getEncoding());
+        }
 
         getContent(request).render(response.getOutputStream(), new JtwigContext(modelMap, getViewResolver().getFunctionRepository()));
     }
@@ -113,14 +113,16 @@ public class JtwigView extends AbstractTemplateView {
         public String getServletName() {
             return JtwigView.this.getBeanName();
         }
+
         public ServletContext getServletContext() {
             return JtwigView.this.getServletContext();
         }
+
         public String getInitParameter(String paramName) {
             return null;
         }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
+        @SuppressWarnings({"unchecked", "rawtypes"})
         public Enumeration getInitParameterNames() {
             return Collections.enumeration(Collections.EMPTY_SET);
         }


### PR DESCRIPTION
Added simple Spring beans resolver to modelmaps which allows doing things like this:

```
<a href="{{ beans.pagination.firstPageUrl(dataTable.page) }}">test</a>
```

We could use some special symbol to referring to beans resolver e.g. @bean or $bean, but both look to be invalid twig syntax:
![hvtbrch](https://f.cloud.github.com/assets/20525/2478861/46a145a4-b089-11e3-8740-4b56f836acbd.png)

Let me know what you think about this idea and implementation.
