### PR TITLE
Enhance issue #97 fix. Division defaults to double division while intege...

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/tree/helper/StrictBinaryOperation.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/tree/helper/StrictBinaryOperation.java
@@ -61,6 +61,8 @@ public class StrictBinaryOperation implements Expression {
             case SUB:
                 return MathOperations.sub(left.calculate(resolver), right.calculate(resolver));
             case DIV:
+                return MathOperations.div(((Number)left.calculate(resolver)).doubleValue(), ((Number)right.calculate(resolver)).doubleValue());
+            case INT_DIV:
                 return MathOperations.div(left.calculate(resolver), right.calculate(resolver));
             case TIMES:
                 return MathOperations.mul(left.calculate(resolver), right.calculate(resolver));

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue97Test.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue97Test.java
@@ -24,8 +24,13 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class Issue97Test extends AbstractJtwigTest {
     @Test
-    public void issue97() throws Exception {
+    public void testDecimalResult() throws Exception {
         when(jtwigRenders(template("{{ 1 / 10 }}")));
+        then(theRenderedTemplate(), is(equalTo("0.1")));
+    }
+    @Test
+    public void testIntegerDivision() throws Exception {
+        when(jtwigRenders(template("{{ 1 // 10 }}")));
         then(theRenderedTemplate(), is(equalTo("0")));
     }
 }


### PR DESCRIPTION
This pull requests results in the following:
{{ 1 / 10 }} = 0.1
{{ 2 / 10 }} = 0.2
{{ 1 // 10 }} = 0

Note I have just default regular division to using doubles, while the INT_DIV operator is now used for default (including) integer division. Perhaps not ideal, but it gets us there. I'm open to criticism.
