### PR TITLE
fix NullPointerException thrown when calling functions accepting varargs...

### DIFF
--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/functions/NullVarArgsTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/functions/NullVarArgsTest.java
@@ -1,0 +1,16 @@
+package com.lyncode.jtwig.acceptance.functions;
+
+import com.lyncode.jtwig.acceptance.AbstractJtwigTest;
+import org.junit.Test;
+
+import static com.lyncode.jtwig.util.SyntacticSugar.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
+public class NullVarArgsTest extends AbstractJtwigTest {
+	@Test
+	public void canExecuteWithNullVarArgsPassed() throws Exception {
+		when(jtwigRenders(template("{{ concat('foo', 'bar', null) }}")));
+		then(theRenderedTemplate(), is(equalTo("foobar")));
+	}
+}

--- a/jtwig-functions/src/main/java/com/lyncode/jtwig/functions/parameters/resolve/impl/ParameterAnnotationResolver.java
+++ b/jtwig-functions/src/main/java/com/lyncode/jtwig/functions/parameters/resolve/impl/ParameterAnnotationResolver.java
@@ -113,7 +113,7 @@ public class ParameterAnnotationResolver implements AnnotatedMethodParameterReso
         if (!resolvedParameter.hasValue()) return true;
         else {
             Object parameterObject = resolvedParameter.get();
-            if (type.isAssignableFrom(parameterObject.getClass()))
+            if (parameterObject != null && type.isAssignableFrom(parameterObject.getClass()))
                 return true;
             return parameterConverter.canConvert(parameterObject, type);
         }

--- a/jtwig-functions/src/test/java/com/lyncode/jtwig/functions/repository/FunctionResolverTest.java
+++ b/jtwig-functions/src/test/java/com/lyncode/jtwig/functions/repository/FunctionResolverTest.java
@@ -20,6 +20,7 @@ import com.lyncode.jtwig.functions.exceptions.FunctionNotFoundException;
 import com.lyncode.jtwig.functions.parameters.GivenParameters;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
@@ -50,6 +51,25 @@ public class FunctionResolverTest {
         underTest.get("test", parameters("one", "two")).execute();
     }
 
+	@Test
+	public void varArgsFunctionShouldWorkWithNullArg() throws Exception {
+		TestClass test = new TestClass();
+		underTest.store(test);
+		assertEquals(1, underTest.get("varargs_test", parameters(new Object[]{null})).execute());
+		assertEquals(2, underTest.get("varargs_test", parameters(new Object[]{"foo", null})).execute());
+		assertEquals(2, underTest.get("varargs_test", parameters(new Object[]{null, "bar"})).execute());
+	}
+
+	@Test
+	public void varArgsOverloadFunctionsShouldWorkWithNullArg() throws Exception {
+		TestClass test = new TestClass();
+		underTest.store(test);
+		assertEquals("strings: 2", underTest.get("varargs_overload", parameters(new Object[]{"foo", "bar"})).execute());
+		assertEquals("ints: 2", underTest.get("varargs_overload", parameters(new Object[]{1, 2})).execute());
+		assertEquals("strings: 2", underTest.get("varargs_overload", parameters(new Object[]{"foo", null})).execute());
+		assertEquals("ints: 2", underTest.get("varargs_overload", parameters(new Object[]{42, null})).execute());
+	}
+
     private GivenParameters parameters(Object... parameters) {
         return new GivenParameters().add(parameters);
     }
@@ -63,5 +83,20 @@ public class FunctionResolverTest {
         public String test (@Parameter Object input) {
             return input.toString();
         }
+
+	    @JtwigFunction(name = "varargs_test")
+	    public int varArgsTest(@Parameter Object... args) {
+		    return args.length;
+	    }
+
+	    @JtwigFunction(name = "varargs_overload")
+	    public String varArgsOverloadWithInts(@Parameter Integer... args) {
+		    return String.format("ints: %d", args.length);
+	    }
+
+	    @JtwigFunction(name = "varargs_overload")
+	    public String varArgsOverloadWithStrings(@Parameter String... args) {
+		    return String.format("strings: %d", args.length);
+	    }
     }
 }


### PR DESCRIPTION
... parameters when passing null as one or more of the parameters

This is a fix for an issue I noticed today with the 3.0.0-SNAPSHOT version. If you have a custom Jtwig function that has a varargs parameter (e.g. the "concat" function), and you pass in one or more null arguments to that parameter then you get a NullPointerException when Jtwig tries to resolve the function:

```
java.lang.NullPointerException
    at com.lyncode.jtwig.functions.parameters.resolve.impl.ParameterAnnotationResolver.canResolveParameterByPosition(ParameterAnnotationResolver.java:116)
    at com.lyncode.jtwig.functions.parameters.resolve.impl.ParameterAnnotationResolver.canResolveParameter(ParameterAnnotationResolver.java:52)
    at com.lyncode.jtwig.functions.parameters.resolve.CompiledParameterResolver.resolveParameter(CompiledParameterResolver.java:52)
    at com.lyncode.jtwig.functions.parameters.resolve.CompiledParameterResolver.resolveParameters(CompiledParameterResolver.java:79)
    at com.lyncode.jtwig.functions.repository.FunctionResolver.get(FunctionResolver.java:71)
    at com.lyncode.jtwig.JtwigContext.executeFunction(JtwigContext.java:76)
    at com.lyncode.jtwig.expressions.model.FunctionElement$Compiled.calculate(FunctionElement.java:81)
    at com.lyncode.jtwig.content.model.compilable.Output$Compiled.render(Output.java:52)
    at com.lyncode.jtwig.content.model.compilable.Sequence$Compiled.render(Sequence.java:80)
    at com.lyncode.jtwig.parser.JtwigParser$CompiledDocument.render(JtwigParser.java:89)
    at com.lyncode.jtwig.acceptance.AbstractJtwigTest.jtwigRenders(AbstractJtwigTest.java:78)
    at com.lyncode.jtwig.acceptance.functions.NullVarArgsTest.canExecuteWithNullVarArgsPassed(NullVarArgsTest.java:13)
```

Let me know if you want the tests I added organized differently.
