### PR TITLE
JtwigTemplate ParserConfiguration usage consistency

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/JtwigTemplate.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/JtwigTemplate.java
@@ -53,7 +53,7 @@ public class JtwigTemplate {
     }
 
     public void output (OutputStream outputStream, JtwigContext context) throws ParseException, CompileException, RenderException {
-        JtwigParser parser = new JtwigParser();
+        JtwigParser parser = new JtwigParser(configuration.parse());
         CompileContext compileContext = new CompileContext(resource, parser, configuration.compile());
         RenderContext renderContext = RenderContext.create(configuration.render(), context, outputStream);
 


### PR DESCRIPTION
This seems to have been just accidentally omitted, but intended (`configuration.compile()` is passed around in a similar way when appropriate).

And it does make it easier to use a custom configuration. :)
