### PR TITLE
Allow use of set with extends tag

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Extends.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Extends.java
@@ -17,9 +17,12 @@ package com.lyncode.jtwig.content.model.compilable;
 import com.lyncode.jtwig.compile.CompileContext;
 import com.lyncode.jtwig.content.api.Compilable;
 import com.lyncode.jtwig.content.api.Renderable;
+import com.lyncode.jtwig.content.api.Tag;
 import com.lyncode.jtwig.exception.CompileException;
 import com.lyncode.jtwig.exception.ParseException;
+import com.lyncode.jtwig.exception.RenderException;
 import com.lyncode.jtwig.exception.ResourceException;
+import com.lyncode.jtwig.render.RenderContext;
 import com.lyncode.jtwig.resource.JtwigResource;
 
 import java.util.ArrayList;
@@ -28,6 +31,7 @@ import java.util.List;
 public class Extends extends AbstractElement {
     private final String relativePath;
     private List<Block> blocks = new ArrayList<>();
+    private List<Compilable> tags = new ArrayList<>();
 
     public Extends(String relativeUrl) {
         this.relativePath = relativeUrl;
@@ -35,15 +39,22 @@ public class Extends extends AbstractElement {
 
     @Override
     public Renderable compile(CompileContext context) throws CompileException {
+        Compiled compiled = new Compiled();
+        for(Compilable tag : tags) {
+            compiled.addTag(tag.compile(context));
+        }
+        
+        // Build the template we're going to extend
         try {
             JtwigResource extendResource = context.retrieve(relativePath);
             context = context.clone().withResource(extendResource);
-
+            
             for (Block block : blocks)
                 context.withReplacement(block.name(), block.compile(context));
 
             Compilable parsed = context.parse(extendResource);
-            return parsed.compile(context);
+            compiled.setContent(parsed.compile(context));
+            return compiled;
         } catch (ResourceException | ParseException e) {
             throw new CompileException(e);
         }
@@ -52,5 +63,34 @@ public class Extends extends AbstractElement {
     public Extends add(Block block) {
         this.blocks.add(block);
         return this;
+    }
+    
+    public Extends addTag(Compilable tag) {
+        this.tags.add(tag);
+        return this;
+    }
+    
+    private static class Compiled implements Renderable {
+        private Renderable content;
+        private List<Renderable> tags = new ArrayList<>();
+
+        @Override
+        public void render(RenderContext context) throws RenderException {
+            for(Renderable tag : tags)
+                tag.render(context);
+            
+            content.render(context);
+        }
+        
+        public Compiled addTag(Renderable tag) {
+            tags.add(tag);
+            return this;
+        }
+        
+        public Compiled setContent(Renderable content) {
+            this.content = content;
+            return this;
+        }
+        
     }
 }

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/SetVariable.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/SetVariable.java
@@ -37,6 +37,15 @@ public class SetVariable extends AbstractElement {
         return new Compiled(variable, assignment.compile(context));
     }
 
+    public String getVariable() {
+        return variable;
+    }
+
+    @Override
+    public String toString() {
+        return variable;
+    }
+
     private static class Compiled implements Renderable {
         private final String variable;
         private final Expression assignment;

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
@@ -118,10 +118,19 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                                         basicParser.spacing(),
                                         basicParser.closeCode(),
                                         push(new Extends(basicParser.pop())),
+                                        
                                         ZeroOrMore(
                                                 basicParser.spacing(),
-                                                block(),
-                                                action(peek(1, Extends.class).add(pop(Block.class)))
+                                                FirstOf(
+                                                        Sequence(
+                                                            block(),
+                                                            action(peek(1, Extends.class).add(pop(Block.class)))
+                                                        ),
+                                                        Sequence(
+                                                            set(),
+                                                            action(peek(1, Extends.class).addTag(pop(SetVariable.class)))
+                                                        )
+                                                )
                                         ),
                                         basicParser.spacing(),
                                         EOI

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue153Test.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue153Test.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.acceptance.issues;
+
+import com.lyncode.jtwig.JtwigContext;
+import com.lyncode.jtwig.JtwigTemplate;
+import com.lyncode.jtwig.acceptance.AbstractJtwigTest;
+import com.lyncode.jtwig.exception.CalculateException;
+import com.lyncode.jtwig.exception.ResourceException;
+import com.lyncode.jtwig.resource.JtwigResource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static com.lyncode.jtwig.util.SyntacticSugar.*;
+import static com.lyncode.jtwig.util.matchers.ExceptionMatcher.exception;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class Issue153Test extends AbstractJtwigTest {
+    private JtwigResource resource = mock(JtwigResource.class);
+    private JtwigContext context = new JtwigContext();
+    private JtwigTemplate underTest = new JtwigTemplate(resource);
+    private ByteArrayOutputStream outputStream;
+    
+    @Test
+    public void supportSetTagInChildTemplate() throws Exception {
+        JtwigResource joaoResource = mock(JtwigResource.class);
+
+        when(resource.resolve("parent")).thenReturn(joaoResource);
+        when(joaoResource.retrieve()).thenReturn(new ByteArrayInputStream("{{ value }}".getBytes()));
+
+        when(resource.retrieve()).thenReturn(new ByteArrayInputStream(("{% extends 'parent' %}" +
+                "{% set value = 'success' %}").getBytes()));
+
+        underTest.output(toTheOutputStream(), context);
+
+        assertThat(theOutput(), is("success"));
+    }
+
+    //~ Helpers ================================================================
+    private String theOutput() {
+        return outputStream.toString();
+    }
+
+    private OutputStream toTheOutputStream() {
+        outputStream = new ByteArrayOutputStream();
+        return outputStream;
+    }
+}


### PR DESCRIPTION
Quick but effective. As we discover other tags that can be used in conjunction with the `extends` tag, we can easily add them by simply modifying the `JtwigContentParser` accordingly.
