### PR TITLE
removed unnecessary session creation

### DIFF
--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
@@ -133,7 +133,7 @@ public class JtwigView extends AbstractTemplateView {
         else if (prefix.startsWith("file://"))
             return new FileJtwigResource(getUrl());
         else
-            return new WebJtwigResource(request.getSession().getServletContext(), getUrl());
+            return new WebJtwigResource(getServletContext(), getUrl());
     }
 
     private JtwigParser jtwigParser() {


### PR DESCRIPTION
Since JtwigView already extends Sping's WebApplicationObjectSupport, it is possible to get the ServletContext without going through the HttpServletRequest—which prior to 3.0 required creating an HttpSession.

Not forcing a session to be created or previously exist is beneficial because it saves resources (time/storage/computational), but more importantly it won't cause an exception if session creation has been disabled on the request.
