### PR TITLE
added the ability to use custom Addons with Spring

### DIFF
--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigView.java
@@ -17,6 +17,7 @@ package com.lyncode.jtwig.mvc;
 import com.lyncode.jtwig.JtwigContext;
 import com.lyncode.jtwig.JtwigModelMap;
 import com.lyncode.jtwig.JtwigTemplate;
+import com.lyncode.jtwig.addons.AddonParser;
 import com.lyncode.jtwig.beans.BeanResolver;
 import com.lyncode.jtwig.configuration.JtwigConfiguration;
 import com.lyncode.jtwig.content.api.Renderable;
@@ -122,8 +123,15 @@ public class JtwigView extends AbstractTemplateView {
     }
 
     private Renderable getCompiledJtwigTemplate(HttpServletRequest request) throws ParseException, CompileException {
+        JtwigParser parser = jtwigParser();
+        if (getViewResolver().getAddonParsers() != null) {
+            for (Class<? extends AddonParser> addonParser : getViewResolver().getAddonParsers()) {
+                parser.withAddonParser(addonParser);
+            }
+        }
+
         return new JtwigTemplate(getResource(request))
-                .compile(jtwigParser());
+                .compile(parser);
     }
 
     private JtwigResource getResource(HttpServletRequest request) {

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigViewResolver.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/mvc/JtwigViewResolver.java
@@ -14,6 +14,7 @@
 
 package com.lyncode.jtwig.mvc;
 
+import com.lyncode.jtwig.addons.AddonParser;
 import com.lyncode.jtwig.configuration.JtwigConfiguration;
 import com.lyncode.jtwig.functions.SpringFunctions;
 import com.lyncode.jtwig.functions.parameters.resolve.HttpRequestParameterResolver;
@@ -53,6 +54,7 @@ public class JtwigViewResolver extends AbstractTemplateViewResolver {
     private JtwigConfiguration configuration = new JtwigConfiguration();
     private FunctionResolver functionRepository = new FunctionResolver();
     private FunctionResolver functionResolver = null;
+    private Class<? extends AddonParser>[] addonParsers = null;
 
     public JtwigViewResolver() {
         setViewClass(requiredViewClass());
@@ -142,5 +144,13 @@ public class JtwigViewResolver extends AbstractTemplateViewResolver {
     public JtwigViewResolver includeFunctions (Object functionBean) {
         functionRepository.store(functionBean);
         return this;
+    }
+
+    public Class<? extends AddonParser>[] getAddonParsers() {
+        return addonParsers;
+    }
+
+    public void setAddonParsers(Class<? extends AddonParser>[] addonParsers) {
+        this.addonParsers = addonParsers;
     }
 }


### PR DESCRIPTION
I didn't see an existing way to use Addons when using a Spring project, and I wanted to create several tags for use with Apache Shiro. This worked and was relatively simple to implement. If this is deemed acceptable and would be approved to be merged in, I can go ahead and add a test for this.
