### PR TITLE
Classpath resource normalization

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/resource/ClasspathJtwigResource.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/resource/ClasspathJtwigResource.java
@@ -41,7 +41,7 @@ public class ClasspathJtwigResource implements JtwigResource {
 
     @Override
     public JtwigResource resolve(String relativePath) throws ResourceException {
-        return new ClasspathJtwigResource(parentOf(resource).append(relativePath).toString());
+        return new ClasspathJtwigResource(parentOf(resource).append(relativePath).normalize());
     }
 
     @Override

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/util/FilePath.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/util/FilePath.java
@@ -50,4 +50,8 @@ public class FilePath {
     public String toString () {
         return file.getPath().replace('\\', '/');
     }
+
+    public String normalize() {
+        return file.toPath().normalize().toString().replace('\\', '/');
+    }
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/ClasspathJtwigResourceTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/ClasspathJtwigResourceTest.java
@@ -35,7 +35,7 @@ public class ClasspathJtwigResourceTest {
 
     @Test
     public void classpathPrefixRemoved() throws Exception {
-        ClasspathJtwigResource resource = new ClasspathJtwigResource("classpath:/templates/unit/sample.twig");
+        ClasspathJtwigResource resource = new ClasspathJtwigResource("classpath:/templates/../templates/unit/sample.twig");
         Assert.assertNotNull(resource.retrieve());
     }
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/util/FilePathTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/util/FilePathTest.java
@@ -13,4 +13,9 @@ public class FilePathTest {
         assertThat(path("/test/test").parent().append("one").toString(), equalTo("/test/one"));
         assertThat(path("/test", "test").parent().toString(), equalTo("/test"));
     }
+
+    @Test
+    public void normalize() throws Exception {
+        assertThat(path("/test/../hello").normalize(), equalTo("/hello"));
+    }
 }


### PR DESCRIPTION
This comes after realising that classloaders are not able to load templates resources from jars (third party jar) using the parent path selector '..'
