### PR TITLE
Fix for #152

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/util/RelationalOperations.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/util/RelationalOperations.java
@@ -44,11 +44,7 @@ public class RelationalOperations {
             return b == null || ((b instanceof Number) && isZero((Number) b));
         if (b == null)
             return (a instanceof Number) && isZero((Number) a);
-        if (a instanceof Long)
-            return (b instanceof Number) && ((Long)a).equals(((Number)b).longValue());
-        if (b instanceof Long)
-            return (a instanceof Number) && ((Long)b).equals(((Number)a).longValue());
-        return a.equals(b);
+        return a.toString().equals(b.toString());
     }
 
     public static boolean isZero(Number number) {

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/operators/RelationalOperators.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/operators/RelationalOperators.java
@@ -3,9 +3,12 @@ package com.lyncode.jtwig.acceptance.operators;
 import com.lyncode.jtwig.JtwigModelMap;
 import com.lyncode.jtwig.JtwigTemplate;
 import com.lyncode.jtwig.acceptance.AbstractJtwigTest;
+import static com.lyncode.jtwig.util.SyntacticSugar.given;
+import static com.lyncode.jtwig.util.SyntacticSugar.then;
+import static com.lyncode.jtwig.util.SyntacticSugar.when;
+import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -22,5 +25,18 @@ public class RelationalOperators extends AbstractJtwigTest {
     public void diffOperatorWhenFalse() throws Exception {
         JtwigTemplate template = JtwigTemplate.fromString("{% if ('one' != 'one') %}Hi{% endif %}");
         assertThat(template.output(context), is(equalTo("")));
+    }
+    
+    @Test
+    public void differentTypesWithSameStringValueAreEqual() throws Exception {
+        given(aModel().withModelAttribute("var1", 5L).withModelAttribute("var2", "5"));
+        when(jtwigRenders(template("{{ var1 == var2 }}")));
+        then(theRenderedTemplate(), is(equalTo("1")));
+    }
+    @Test
+    public void differentTypesWithSameStringValueAreEqual2() throws Exception {
+        given(aModel().withModelAttribute("var1", 'a').withModelAttribute("var2", "a"));
+        when(jtwigRenders(template("{{ var1 == var2 }}")));
+        then(theRenderedTemplate(), is(equalTo("1")));
     }
 }


### PR DESCRIPTION
Equivalence checking is now loose, just like Twig's equivalence checking. Type no longer matters when performing equivalence check.
