### PR TITLE
Extends now handles expression-based and array-based extensions per #206

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
@@ -126,10 +126,11 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                         keyword(EXTENDS),
                         mandatory(
                                 Sequence(
-                                        basicParser.stringLiteral(),
+                                        expressionParser.expression(),
+                                        push(new Extends(expressionParser.pop())),
                                         basicParser.spacing(),
                                         basicParser.closeCode(),
-                                        push(new Extends(basicParser.pop())),
+                                        
                                         ZeroOrMore(
                                                 basicParser.spacing(),
                                                 block(),
@@ -138,7 +139,7 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                                         basicParser.spacing(),
                                         EOI
                                 ),
-                                new ParseException("Wrong include syntax")
+                                new ParseException("Wrong extends syntax")
                         )
                 )
         );

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/JtwigTemplateTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/JtwigTemplateTest.java
@@ -76,6 +76,56 @@ public class JtwigTemplateTest {
 
         assertThat(theOutput(), is("Block one and two"));
     }
+    
+    @Test
+    public void testExtendsVariableDefinedTemplate() throws Exception {
+        JtwigResource oneResource = mock(JtwigResource.class);
+        JtwigResource twoResource = mock(JtwigResource.class);
+        
+        when(resource.resolve("num-one")).thenReturn(oneResource);
+        when(resource.resolve("num-two")).thenReturn(twoResource);
+        
+        when(oneResource.retrieve()).thenReturn(new ByteArrayInputStream("first".getBytes()));
+        when(twoResource.retrieve()).thenReturn(new ByteArrayInputStream("second".getBytes()));
+        
+        when(resource.retrieve()).thenReturn(new ByteArrayInputStream("{% extends var %}".getBytes()));
+
+        context.withModelAttribute("var", "num-two");
+        underTest.output(toTheOutputStream(), context);
+        assertThat(theOutput(), is("second"));
+    }
+    
+    @Test
+    public void testExtendsExpression() throws Exception {
+        JtwigResource oneResource = mock(JtwigResource.class);
+        JtwigResource twoResource = mock(JtwigResource.class);
+        
+        when(resource.resolve("num-one")).thenReturn(oneResource);
+        when(resource.resolve("num-two")).thenReturn(twoResource);
+        
+        when(oneResource.retrieve()).thenReturn(new ByteArrayInputStream("first".getBytes()));
+        when(twoResource.retrieve()).thenReturn(new ByteArrayInputStream("second".getBytes()));
+        
+        when(resource.retrieve()).thenReturn(new ByteArrayInputStream("{% extends var ? 'num-one' : 'num-two' %}".getBytes()));
+
+        context.withModelAttribute("var", false);
+        underTest.output(toTheOutputStream(), context);
+        assertThat(theOutput(), is("second"));
+    }
+    
+    @Test
+    public void testExtendsWithArrayOfTemplates() throws Exception {
+        JtwigResource twoResource = mock(JtwigResource.class);
+        
+        when(resource.resolve("num-two")).thenReturn(twoResource);
+        
+        when(twoResource.retrieve()).thenReturn(new ByteArrayInputStream("second".getBytes()));
+        
+        when(resource.retrieve()).thenReturn(new ByteArrayInputStream("{% extends ['num-one','num-two','num-three'] %}".getBytes()));
+
+        underTest.output(toTheOutputStream(), context);
+        assertThat(theOutput(), is("second"));
+    }
 
     private String theOutput() {
         return outputStream.toString();


### PR DESCRIPTION
Note that the two examples provided by http://twig.sensiolabs.org/doc/tags/extends.html#dynamic-inheritance function properly. Any expression may be used here, though if the expression does not produce a String or a valid template location, you're going to get a resource exception. This takes care of both sections as noted in the original issue #206.
