### PR TITLE
Include now supports variable inclusion per #193

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
@@ -306,7 +306,7 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                                 action(beforeBeginTrim()),
                                 Optional(
                                         keyword(JtwigKeyword.WITH),
-                                        expressionParser.map(),
+                                        FirstOf(expressionParser.map(), expressionParser.variable()),
                                         action(peek(1, Include.class).with(expressionParser.pop()))
                                 ),
                                 closeCode(),

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
@@ -27,4 +27,10 @@ public class IncludeTest extends AbstractJtwigTest {
         when(jtwigRenders(templateResource("templates/acceptance/include/main.twig")));
         then(theRenderedTemplate(), is(equalTo("test")));
     }
+    
+    @Test
+    public void includeWithVars() throws Exception {
+        when(jtwigRenders(templateResource("templates/acceptance/include/main-vars.twig")));
+        then(theRenderedTemplate(), is(equalTo("hello, world")));
+    }
 }

--- a/jtwig-core/src/test/resources/templates/acceptance/include/main-vars.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/include/main-vars.twig
@@ -1,0 +1,1 @@
+{% set vars = { variable: 'hello, world' } %}{% include 'included.twig' with vars %}


### PR DESCRIPTION
Now supports stuff like:

```
{% set vars = {"var1": "hello", "var2": "world"} %}
{% include "template.twig" with vars %}
```
