### PR TITLE
Quick fix for charset rendering issue pursuant to #210

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Output.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Output.java
@@ -51,7 +51,7 @@ public class Output extends AbstractElement {
             try {
                 Object calculate = expression.calculate(context);
                 if (calculate != null)
-                    context.write(toTwig(calculate).getBytes());
+                    context.write(toTwig(calculate).getBytes(context.configuration().charset()));
             } catch (IOException | CalculateException e) {
                 throw new RenderException(e);
             }

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/render/config/RenderConfiguration.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/render/config/RenderConfiguration.java
@@ -15,10 +15,12 @@
 package com.lyncode.jtwig.render.config;
 
 import com.lyncode.jtwig.functions.repository.impl.MapFunctionRepository;
+import java.nio.charset.Charset;
 
 public class RenderConfiguration {
     private boolean strictMode = false;
     private boolean logNonStrictMode = true;
+    private Charset charset = Charset.forName("UTF-8");
     private final MapFunctionRepository functionRepository = new MapFunctionRepository();
 
     public boolean strictMode() {
@@ -38,8 +40,19 @@ public class RenderConfiguration {
         this.logNonStrictMode = logNonStrictMode;
         return this;
     }
+    
+    public Charset charset() {
+        return charset;
+    }
+    
+    public RenderConfiguration charset(Charset charset) {
+        this.charset = charset;
+        return this;
+    }
 
     public MapFunctionRepository functionRepository() {
         return functionRepository;
     }
+    
+    
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue210Test.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue210Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 thomas.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.acceptance.issues;
+
+import com.lyncode.jtwig.acceptance.AbstractJtwigTest;
+import static com.lyncode.jtwig.util.SyntacticSugar.given;
+import static com.lyncode.jtwig.util.SyntacticSugar.then;
+import static com.lyncode.jtwig.util.SyntacticSugar.when;
+import java.nio.charset.Charset;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import org.junit.Test;
+
+/**
+ * 
+ */
+public class Issue210Test extends AbstractJtwigTest {
+    @Test
+    public void testNonUTFEncoding() throws Exception {
+        theConfiguration().render().charset(Charset.forName("ISO-8859-1"));
+        given(aModel().withModelAttribute("text", "tête de bou  간편한 설치 및 사용"));
+        when(jtwigRenders(template("{{ text }}")));
+        then(theRenderedTemplate(), is(equalTo("t�te de bou  ??? ?? ? ??")));
+    }
+    @Test
+    public void testUTFEncoding() throws Exception {
+        given(aModel().withModelAttribute("text", "tête de bou  간편한 설치 및 사용"));
+        when(jtwigRenders(template("{{ text }}")));
+        then(theRenderedTemplate(), is(equalTo("tête de bou  간편한 설치 및 사용")));
+    }
+}


### PR DESCRIPTION
Pursuant to #210, this fix resolves charset encoding/rendering issues by allowing developers to specify a charset, and defaulting the Jtwig charset to UTF-8 pursuant to http://twig.sensiolabs.org/doc/api.html#environment-options. 
