### PR TITLE
Updated list comprehension behaviour to support operating on expressions per #78

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/expressions/model/ValueRange.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/expressions/model/ValueRange.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.expressions.model;
+
+import com.lyncode.jtwig.compile.CompileContext;
+import com.lyncode.jtwig.exception.CalculateException;
+import com.lyncode.jtwig.exception.CompileException;
+import com.lyncode.jtwig.expressions.api.CompilableExpression;
+import com.lyncode.jtwig.expressions.api.Expression;
+import com.lyncode.jtwig.render.RenderContext;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValueRange implements CompilableExpression {
+    private CompilableExpression start;
+    private CompilableExpression end;
+
+    public ValueRange withStart(CompilableExpression start) {
+        this.start = start;
+        return this;
+    }
+    
+    public ValueRange withEnd(CompilableExpression end) {
+        this.end = end;
+        return this;
+    }
+    
+    @Override
+    public Expression compile(CompileContext context) throws CompileException {
+        return new Compiled(start.compile(context), end.compile(context));
+    }
+    
+    private static class Compiled implements Expression {
+        private final Expression start;
+        private final Expression end;
+
+        private Compiled(Expression start, Expression end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public Object calculate(RenderContext context) throws CalculateException {
+            Object start = this.start.calculate(context);
+            Object end = this.end.calculate(context);
+            
+            // In twig, numbers take precedence
+            int startInt;
+            int endInt;
+            int step = 1;
+            if (start instanceof Number || end instanceof Number) {
+                startInt = start instanceof Number ? ((Number)start).intValue() : 0;
+                endInt = end instanceof Number ? ((Number)end).intValue() : 0;
+            } else {
+                if (start instanceof Character) {
+                    startInt = ((Character)start).charValue();
+                } else if (start instanceof CharSequence) {
+                    startInt = ((CharSequence)start).charAt(0);
+                } else {
+                    startInt = 0;
+                }
+                if (end instanceof Character) {
+                    endInt = ((Character)end).charValue();
+                } else if (end instanceof CharSequence) {
+                    endInt = ((CharSequence)end).charAt(0);
+                } else {
+                    endInt = 0;
+                }
+            }
+            
+            // Handle negative progressions
+            if (startInt > endInt) {
+                step = -step;
+            }
+
+            // Build the list and convert if necessary
+            List results;
+            if (start instanceof Number || end instanceof Number) {
+                results = new ArrayList<Number>();
+                for (int i = startInt; (step > 0) ? i <= endInt : i >= endInt; i += step) {
+                    results.add(i);
+                }
+            } else {
+                results = new ArrayList<String>();
+                for (int i = startInt; (step > 0) ? i <= endInt : i >= endInt; i += step) {
+                    results.add(Character.toString((char)i));
+                }
+            }
+            return results;
+        }
+    }
+}

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ForExpressionTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ForExpressionTest.java
@@ -119,7 +119,14 @@ public class ForExpressionTest {
         context.withModelAttribute("obj", new Obj());
         context.withModelAttribute("name", "Test");
         assertThat(template.output(context), is("ab"));
-        
+    }
+    
+    @Test
+    public void iterateOnSequence () throws ParseException, CompileException, RenderException {
+        JtwigTemplate template = JtwigTemplate.fromString("{% for value in start..end %}{{ value }}{% endfor %}");
+        JtwigModelMap context = new JtwigModelMap();
+        context.withModelAttribute("start", 'b').withModelAttribute("end", 'l');
+        assertThat(template.output(context), is("bcdefghijkl"));
     }
     
     public static class Obj {

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ListExpressionTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ListExpressionTest.java
@@ -27,26 +27,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ListExpressionTest extends AbstractJtwigTest {
     @Test
     public void integerListByComprehension () throws ParseException, CompileException, RenderException {
-        JtwigTemplate template = JtwigTemplate.fromString("{{ 1..5 | join(',') }}");
+        JtwigTemplate template = JtwigTemplate.fromString("{{ (1..5) | join(',') }}");
         JtwigModelMap context = new JtwigModelMap();
         assertThat(template.output(context), is("1,2,3,4,5"));
     }
     @Test
     public void integerListByComprehensionReverse () throws ParseException, CompileException, RenderException {
-        JtwigTemplate template = JtwigTemplate.fromString("{{ 5..1 | join(',') }}");
+        JtwigTemplate template = JtwigTemplate.fromString("{{ (5..1) | join(',') }}");
         JtwigModelMap context = new JtwigModelMap();
         assertThat(template.output(context), is("5,4,3,2,1"));
     }
 
     @Test
     public void characterListByComprehension () throws ParseException, CompileException, RenderException {
-        JtwigTemplate template = JtwigTemplate.fromString("{{ 'a'..'c' | join }}");
+        JtwigTemplate template = JtwigTemplate.fromString("{{ ('a'..'c') | join }}");
         JtwigModelMap context = new JtwigModelMap();
         assertThat(template.output(context), is("abc"));
     }
     @Test
     public void characterListByComprehensionReverse () throws ParseException, CompileException, RenderException {
-        JtwigTemplate template = JtwigTemplate.fromString("{{ 'c'..'a' | join }}");
+        JtwigTemplate template = JtwigTemplate.fromString("{{ ('c'.. 'a') | join }}");
         JtwigModelMap context = new JtwigModelMap();
         assertThat(template.output(context), is("cba"));
     }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue76Test.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/issues/Issue76Test.java
@@ -56,14 +56,4 @@ public class Issue76Test extends AbstractJtwigTest {
             then(e.getCause().getMessage(), startsWith("templates/issue76/test2.twig -> Line 1, column 23:"));
         }
     }
-
-    @Test
-    public void shouldGiveNiceExplanationForNonExistingExpression() throws Exception {
-        try {
-            when(jtwigRenders(template("{{ 'abc'..'abc' }}")));
-            fail();
-        } catch (ParseException e) {
-            then(e.getMessage(), containsString("String Source -> Line 1, column 16: Only integers and characters are allowed in comprehension lists"));
-        }
-    }
 }


### PR DESCRIPTION
Per #78, Jtwig now supports list comprehension of expressions.

A couple of interesting points:
1. Just like Twig, numbers are preferred. If a character|string|object is used in conjunction with a number, the character|string|object will end up as a 0, which is typical for Twig.
2. Binary operations now check to ensure that the operator is only present a single time. This was to ensure that the double dot operator wouldn't be matched during parsing. This had no effect on unit or acceptance tests at the time of writing.
3. The expression parser has an added bit of goodness, the InValueStack class and associated rule methods. This allows rules to determine whether a given class is contained within a specific slice of the value stack. This was necessary in order to prevent the list comprehension rule from eagerly matching itself while trying to grab the left-side expression.
