### PR TITLE
Foreach loop variable fix per #198

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/For.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/For.java
@@ -170,12 +170,20 @@ public class For extends Content<For> {
             return length;
         }
 
-        public int getIndex() {
+        public int getIndex0() {
             return index;
         }
+        
+        public int getIndex() {
+            return index + 1;
+        }
 
-        public int getRevindex() {
+        public int getRevindex0() {
             return length - index - 1;
+        }
+        
+        public int getRevindex() {
+            return length - index;
         }
 
         public boolean isFirst() {

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ForExpressionTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/ForExpressionTest.java
@@ -51,7 +51,7 @@ public class ForExpressionTest {
     @Test
     public void forLoopMustExposeTheLoopVariable () throws ParseException, CompileException, RenderException {
         JtwigTemplate template = JtwigTemplate.fromString("{% for item in list %}" +
-                "{% if loop.first %}First {% elseif loop.last %}Last{% else %}I: {{ loop.index }} R: {{ loop.revindex }} {% endif %}" +
+                "{% if loop.first %}First {% elseif loop.last %}Last{% else %}I: {{ loop.index0 }} R: {{ loop.revindex0 }} {% endif %}" +
                 "{% endfor %}");
         JtwigModelMap context = new JtwigModelMap();
         ArrayList<String> value = new ArrayList<String>();
@@ -62,6 +62,22 @@ public class ForExpressionTest {
         value.add("e");
         context.withModelAttribute("list", value);
         assertThat(template.output(context), is("First I: 1 R: 3 I: 2 R: 2 I: 3 R: 1 Last"));
+    }
+
+    @Test
+    public void ensureProperLoopVariableIndexing () throws ParseException, CompileException, RenderException {
+        JtwigTemplate template = JtwigTemplate.fromString("{% for item in list %}" +
+                "{{ loop.index0 }}{{ loop.index }}{{ loop.revindex0 }}{{ loop.revindex }} " +
+                "{% endfor %}");
+        JtwigModelMap context = new JtwigModelMap();
+        ArrayList<String> value = new ArrayList<String>();
+        value.add("a");
+        value.add("b");
+        value.add("c");
+        value.add("d");
+        value.add("e");
+        context.withModelAttribute("list", value);
+        assertThat(template.output(context), is("0145 1234 2323 3412 4501 "));
     }
 
     @Test

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/addons/concurrent/ConcurrentTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/addons/concurrent/ConcurrentTest.java
@@ -62,7 +62,7 @@ public class ConcurrentTest extends AbstractAddonTest {
     @Test
     public void test_concurrent_1() throws Exception {
         JtwigTemplate template = JtwigTemplate.fromString("{% concurrent %}{% for item in list %}" +
-                                                           "{% if loop.first %}{% concurrent %}First {% endconcurrent %}{% elseif loop.last %}{% concurrent %}Last{% endconcurrent %}{% else %}I: {{ loop.index }} R: {{ loop.revindex }} {% endif %}" +
+                                                           "{% if loop.first %}{% concurrent %}First {% endconcurrent %}{% elseif loop.last %}{% concurrent %}Last{% endconcurrent %}{% else %}I: {{ loop.index0 }} R: {{ loop.revindex0 }} {% endif %}" +
                                                            "{% endfor %}{% endconcurrent %}");
         JtwigModelMap context = new JtwigModelMap();
         ArrayList<String> value = new ArrayList<String>();


### PR DESCRIPTION
loop.index0 and loop.revindex0 are now 0-index while loop.index and loop.revindex are 1-index. Exact match with Twig. Obviously the backward-incompatible nature of the fix precludes us from pushing it until 4.0.0
