### PR TITLE
Add block function persuant to #88

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/expressions/model/BlockFunction.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/expressions/model/BlockFunction.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.expressions.model;
+
+import com.lyncode.jtwig.compile.CompileContext;
+import com.lyncode.jtwig.content.api.Renderable;
+import com.lyncode.jtwig.exception.CalculateException;
+import com.lyncode.jtwig.exception.CompileException;
+import com.lyncode.jtwig.exception.RenderException;
+import com.lyncode.jtwig.expressions.api.CompilableExpression;
+import com.lyncode.jtwig.expressions.api.Expression;
+import com.lyncode.jtwig.parser.model.JtwigPosition;
+import com.lyncode.jtwig.render.RenderContext;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+
+public class BlockFunction extends AbstractCompilableExpression {
+    private final List<CompilableExpression> arguments = new ArrayList<>();
+
+    public BlockFunction(JtwigPosition position) {
+        super(position);
+    }
+
+    public BlockFunction add(CompilableExpression argument) {
+        arguments.add(argument);
+        return this;
+    }
+
+    @Override
+    public Expression compile(CompileContext context) throws CompileException {
+        if (arguments.isEmpty()) {
+            throw new CompileException("Block function requires a single argument");
+        }
+        List<Expression> compiledArguments = new ArrayList<>();
+        for (CompilableExpression argument : arguments) {
+            compiledArguments.add(argument.compile(context));
+        }
+        return new Compiled(position(), compiledArguments, context);
+    }
+
+    public static class Compiled implements Expression {
+        private final JtwigPosition position;
+        private final List<Expression> arguments;
+        private final CompileContext compileContext;
+
+        public Compiled(JtwigPosition position, List<Expression> arguments, CompileContext compileContext) {
+            this.position = position;
+            this.arguments = new CopyOnWriteArrayList<>(arguments);
+            this.compileContext = compileContext;
+        }
+
+        @Override
+        public Object calculate(RenderContext context) throws CalculateException {
+            // Clone the RenderContext so that we can isolate the renderstream
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                RenderContext isolated = context.newRenderContext(baos);
+                Renderable block = compileContext.replacement(getFirstArgument().calculate(isolated).toString());
+                if (block != null) {
+                    block.render(isolated);
+                }
+                return baos.toString();
+            } catch (IOException e) {
+            } catch (RenderException e) {
+                throw new CalculateException("Unable to render the block.", e);
+            }
+            return null;
+        }
+
+        public Expression getFirstArgument() {
+            return this.arguments.get(0);
+        }
+    }
+}

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigExpressionParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigExpressionParser.java
@@ -219,6 +219,7 @@ public class JtwigExpressionParser extends JtwigBaseParser<CompilableExpression>
     Rule elementar() {
         return FirstOf(
                 mapEntry(),
+                blockFunction(),
                 function(),
                 map(),
                 list(),
@@ -332,6 +333,28 @@ public class JtwigExpressionParser extends JtwigBaseParser<CompilableExpression>
                                 symbol(CLOSE_PARENT)
                         ),
                         new ParseException("Wrong function syntax")
+                )
+        );
+    }
+    
+    public Rule blockFunction() {
+        return Sequence(
+                "block",
+                basic.spacing(),
+                push(new BlockFunction(currentPosition())),
+                symbol(OPEN_PARENT),
+                mandatory(
+                        Sequence(
+                                expression(),
+                                action(peek(1, BlockFunction.class).add(pop())),
+                                ZeroOrMore(
+                                        symbol(COMMA),
+                                        expression(),
+                                        action((peek(1, BlockFunction.class)).add(pop()))
+                                ),
+                                symbol(CLOSE_PARENT)
+                        ),
+                        new ParseException("Invalid block function syntax")
                 )
         );
     }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/functions/BlockFunctionTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/functions/BlockFunctionTest.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.acceptance.functions;
+
+import com.lyncode.jtwig.acceptance.AbstractJtwigTest;
+import static com.lyncode.jtwig.util.SyntacticSugar.given;
+import static com.lyncode.jtwig.util.SyntacticSugar.then;
+import static com.lyncode.jtwig.util.SyntacticSugar.when;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import org.junit.Test;
+
+public class BlockFunctionTest extends AbstractJtwigTest {
+    @Test
+    public void ensureBlockFunctionWorksWithVariables() throws Exception {
+        given(aModel().withModelAttribute("var", "title"));
+        when(jtwigRenders(templateResource("templates/acceptance/block/tested.twig")));
+        then(theRenderedTemplate(), is(equalTo("title!")));
+    }
+    @Test
+    public void ensureBlockFunctionWorksWithVariables2() throws Exception {
+        given(aModel().withModelAttribute("var", "body"));
+        when(jtwigRenders(templateResource("templates/acceptance/block/tested.twig")));
+        then(theRenderedTemplate(), is(equalTo("body!")));
+    }
+}

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/expressions/model/BlockFunctionTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/expressions/model/BlockFunctionTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lyncode.jtwig.unit.expressions.model;
+
+import com.lyncode.jtwig.compile.CompileContext;
+import com.lyncode.jtwig.exception.CompileException;
+import com.lyncode.jtwig.expressions.model.BlockFunction;
+import com.lyncode.jtwig.expressions.model.Constant;
+import com.lyncode.jtwig.expressions.model.FunctionElement;
+import com.lyncode.jtwig.functions.parameters.input.InputParameters;
+import com.lyncode.jtwig.render.RenderContext;
+import org.junit.Assert;
+import org.junit.Test;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BlockFunctionTest {
+    
+    @Test
+    public void complainsOnLackOfArgument() throws Exception {
+        BlockFunction block = new BlockFunction(null);
+        CompileContext compilectx = mock(CompileContext.class);
+        try {
+            block.compile(compilectx);
+            Assert.fail("Should have complained about lack of argument");
+        } catch (CompileException e) {
+            Assert.assertEquals("Block function requires a single argument", e.getMessage());
+        }
+    }
+
+    @Test
+    public void expressionCalculationQueriesContext() throws Exception {
+        RenderContext context = mock(RenderContext.class);
+        CompileContext compilectx = mock(CompileContext.class);
+        BlockFunction block = new BlockFunction(null);
+        block.add(new Constant<>("title"));
+        block.compile(compilectx)
+                .calculate(context);
+
+        verify(compilectx).replacement(eq("title"));
+    }
+}

--- a/jtwig-core/src/test/resources/templates/acceptance/block/master.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/block/master.twig
@@ -1,0 +1,1 @@
+{{ block(block('value')) }}

--- a/jtwig-core/src/test/resources/templates/acceptance/block/tested.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/block/tested.twig
@@ -1,0 +1,5 @@
+{% extends "master.twig" %}
+
+{% block value %}{{ var }}{% endblock %}
+{% block title %}title!{% endblock %}
+{% block body %}body!{% endblock %}


### PR DESCRIPTION
Some things to note:
1. Accepts any expression as the block name parameter, just like Twig.
2. The block function can be nested, just like in Twig, and as exemplified in the associated acceptance tests.
3. Unlike Twig, the 'block' keyword cannot be used as the name of a block or variable. I attempted to fix that here, but it was going to be too large a change and far too unrelated. Will pull that out into a different issue.
