### PR TITLE
Support include...ignore missing pursuant to #130

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Include.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/content/model/compilable/Include.java
@@ -30,6 +30,7 @@ public class Include extends AbstractElement {
     private final String relativePath;
     private final JtwigPosition position;
     private CompilableExpression withExpression = null;
+    private boolean ignoreMissing = false;
 
     public Include(JtwigPosition position, String relativePath) {
         this.position = position;
@@ -40,11 +41,19 @@ public class Include extends AbstractElement {
         this.withExpression = with;
         return this;
     }
+    
+    public Include setIgnoreMissing (boolean ignoreMissing) {
+        this.ignoreMissing = ignoreMissing;
+        return this;
+    }
 
     @Override
     public Renderable compile(CompileContext context) throws CompileException {
         try {
             JtwigResource resource = context.retrieve(relativePath);
+            if (!resource.exists() && ignoreMissing) {
+                return new Missing();
+            }
             context = context.clone().withResource(resource);
 
             Compiled compiled = new Compiled(position, context.parse(resource).compile(context));
@@ -85,5 +94,10 @@ public class Include extends AbstractElement {
             } else
                 renderable.render(context);
         }
+    }
+    
+    public static class Missing implements Renderable {
+        @Override
+        public void render(RenderContext context) throws RenderException {}
     }
 }

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/model/JtwigKeyword.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/model/JtwigKeyword.java
@@ -46,6 +46,7 @@ public enum JtwigKeyword {
 
     SET("set"),
     INCLUDE("include"),
+    IGNORE_MISSING("ignore missing"),
     EXCLUDE("exclude"),
     IN("in"),
     IS("is"),

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
@@ -306,6 +306,10 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                                 push(new Include(currentPosition(), basicParser.pop())),
                                 action(beforeBeginTrim()),
                                 Optional(
+                                        keyword(JtwigKeyword.IGNORE_MISSING),
+                                        action(peek(Include.class).setIgnoreMissing(true))
+                                ),
+                                Optional(
                                         keyword(JtwigKeyword.WITH),
                                         FirstOf(expressionParser.map(), expressionParser.variable()),
                                         action(peek(1, Include.class).with(expressionParser.pop()))

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/resource/ClasspathJtwigResource.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/resource/ClasspathJtwigResource.java
@@ -32,6 +32,11 @@ public class ClasspathJtwigResource implements JtwigResource {
     }
 
     @Override
+    public boolean exists() {
+        return this.getClass().getClassLoader().getResource(this.resource) != null;
+    }
+
+    @Override
     public InputStream retrieve() throws ResourceException {
         InputStream resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(this.resource);
         if (resourceAsStream == null)

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/resource/FileJtwigResource.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/resource/FileJtwigResource.java
@@ -36,6 +36,11 @@ public class FileJtwigResource implements JtwigResource {
     }
 
     @Override
+    public boolean exists() {
+        return file.exists();
+    }
+
+    @Override
     public InputStream retrieve() throws ResourceException {
         try {
             return new FileInputStream(file);

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/resource/JtwigResource.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/resource/JtwigResource.java
@@ -19,6 +19,7 @@ import com.lyncode.jtwig.exception.ResourceException;
 import java.io.InputStream;
 
 public interface JtwigResource {
+    boolean exists ();
     InputStream retrieve () throws ResourceException;
     JtwigResource resolve (String relativePath) throws ResourceException;
 }

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/resource/StringJtwigResource.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/resource/StringJtwigResource.java
@@ -27,6 +27,11 @@ public class StringJtwigResource implements JtwigResource {
     }
 
     @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
     public InputStream retrieve() throws ResourceException {
         return new ByteArrayInputStream(content.getBytes());
     }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
@@ -14,12 +14,14 @@
 
 package com.lyncode.jtwig.acceptance;
 
+import com.lyncode.jtwig.exception.CompileException;
 import org.junit.Test;
 
 import static com.lyncode.jtwig.util.SyntacticSugar.then;
 import static com.lyncode.jtwig.util.SyntacticSugar.when;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import org.junit.Assert;
 
 public class IncludeTest extends AbstractJtwigTest {
     @Test
@@ -32,5 +34,19 @@ public class IncludeTest extends AbstractJtwigTest {
     public void includeWithVars() throws Exception {
         when(jtwigRenders(templateResource("templates/acceptance/include/main-vars.twig")));
         then(theRenderedTemplate(), is(equalTo("hello, world")));
+    }
+    
+    @Test
+    public void includeMissingWithoutFlagShouldThrowException() throws Exception {
+        try {
+            when(jtwigRenders(templateResource("templates/acceptance/include/ignore-missing-exception.twig")));
+            Assert.fail("Should have received a compile exception stating that the resource could not be found.");
+        } catch (CompileException e) {}
+    }
+    
+    @Test
+    public void includeMissingWithFlagShouldNotThrowException() throws Exception {
+        when(jtwigRenders(templateResource("templates/acceptance/include/ignore-missing-working.twig")));
+        then(theRenderedTemplate(), is(equalTo("start--end")));
     }
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/ClasspathJtwigResourceTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/ClasspathJtwigResourceTest.java
@@ -15,10 +15,11 @@
 package com.lyncode.jtwig.unit.resource;
 
 import com.lyncode.jtwig.resource.ClasspathJtwigResource;
-import junit.framework.Assert;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ClasspathJtwigResourceTest {
     private ClasspathJtwigResource underTest = new ClasspathJtwigResource("/templates/unit/sample.twig");
@@ -36,6 +37,12 @@ public class ClasspathJtwigResourceTest {
     @Test
     public void classpathPrefixRemoved() throws Exception {
         ClasspathJtwigResource resource = new ClasspathJtwigResource("classpath:/templates/../templates/unit/sample.twig");
-        Assert.assertNotNull(resource.retrieve());
+        assertNotNull(resource.retrieve());
+    }
+    
+    @Test
+    public void ensureExistsMethodWorksProperly() throws Exception {
+        assertTrue(underTest.exists());
+        assertFalse(underTest.resolve("invalid.twig").exists());
     }
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/FileJtwigResourceTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/unit/resource/FileJtwigResourceTest.java
@@ -16,6 +16,7 @@ package com.lyncode.jtwig.unit.resource;
 
 import com.lyncode.jtwig.exception.ResourceException;
 import com.lyncode.jtwig.resource.FileJtwigResource;
+import com.lyncode.jtwig.resource.JtwigResource;
 import org.junit.Test;
 import org.parboiled.common.FileUtils;
 
@@ -38,6 +39,15 @@ public class FileJtwigResourceTest {
         assertThat(FileUtils.readAllText(resource.retrieve()), notNullValue());
         assertThat(resource.toString(), endsWith("/templates/unit/sample.twig"));
         assertThat(resource.resolve("other.jtwig"), notNullValue());
+    }
+    
+    @Test
+    public void ensureExistsMethodWorksProperly() throws Exception {
+        JtwigResource resource = new FileJtwigResource(new File(getClass().getResource("/templates/unit/sample.twig").toURI()));
+        assertThat(resource.exists(), equalTo(true));
+        
+        resource = resource.resolve("invalid.twig");
+        assertThat(resource.exists(), equalTo(false));
     }
 
     @Test

--- a/jtwig-core/src/test/resources/templates/acceptance/include/ignore-missing-exception.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/include/ignore-missing-exception.twig
@@ -1,0 +1,1 @@
+{% include 'invalid.twig' %}

--- a/jtwig-core/src/test/resources/templates/acceptance/include/ignore-missing-working.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/include/ignore-missing-working.twig
@@ -1,0 +1,1 @@
+start-{% include 'invalid.twig' ignore missing %}-end

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/resource/WebJtwigResource.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/resource/WebJtwigResource.java
@@ -20,14 +20,23 @@ import javax.servlet.ServletContext;
 import java.io.InputStream;
 
 import static com.lyncode.jtwig.util.FilePath.parentOf;
+import java.net.MalformedURLException;
 
 public class WebJtwigResource implements JtwigResource {
-    private ServletContext servletContext;
-    private String url;
+    private final ServletContext servletContext;
+    private final String url;
 
     public WebJtwigResource(ServletContext servletContext, String url) {
         this.servletContext = servletContext;
         this.url = url;
+    }
+
+    @Override
+    public boolean exists() {
+        try {
+            return servletContext.getResource(url) != null;
+        } catch (MalformedURLException ex) {}
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This should be an entirely backward compatible change.

The JtwigResource.exists() method has been introduced to allow us to determine early on whether or not a resource exists without having to load it. I added an `Include$Missing` inner class that is a blank `Renderable` as it makes operation simpler and more explicit.
