### PR TITLE
Support include-only and include-with-only syntax pursuant to #129

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/model/JtwigKeyword.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/model/JtwigKeyword.java
@@ -46,6 +46,7 @@ public enum JtwigKeyword {
 
     SET("set"),
     INCLUDE("include"),
+    ONLY("only"),
     EXCLUDE("exclude"),
     IN("in"),
     IS("is"),

--- a/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/parser/parboiled/JtwigContentParser.java
@@ -310,6 +310,10 @@ public class JtwigContentParser extends JtwigBaseParser<Compilable> {
                                         FirstOf(expressionParser.map(), expressionParser.variable()),
                                         action(peek(1, Include.class).with(expressionParser.pop()))
                                 ),
+                                Optional(
+                                        keyword(JtwigKeyword.ONLY),
+                                        action(peek(Include.class).setIsolated(true))
+                                ),
                                 closeCode(),
                                 action(afterEndTrim())
                         ),

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/acceptance/IncludeTest.java
@@ -16,6 +16,7 @@ package com.lyncode.jtwig.acceptance;
 
 import org.junit.Test;
 
+import static com.lyncode.jtwig.util.SyntacticSugar.given;
 import static com.lyncode.jtwig.util.SyntacticSugar.then;
 import static com.lyncode.jtwig.util.SyntacticSugar.when;
 import static org.hamcrest.core.Is.is;
@@ -32,5 +33,19 @@ public class IncludeTest extends AbstractJtwigTest {
     public void includeWithVars() throws Exception {
         when(jtwigRenders(templateResource("templates/acceptance/include/main-vars.twig")));
         then(theRenderedTemplate(), is(equalTo("hello, world")));
+    }
+    
+    @Test
+    public void includeOnlyCannotAccessContext() throws Exception {
+        given(aModel().add("variable", "test"));
+        when(jtwigRenders(templateResource("templates/acceptance/include/include-only.twig")));
+        then(theRenderedTemplate(), is(equalTo("")));
+    }
+    
+    @Test
+    public void includeWithOnlyCannotAccessContext() throws Exception {
+        given(aModel().add("variable", "pink"));
+        when(jtwigRenders(templateResource("templates/acceptance/include/include-with-only.twig")));
+        then(theRenderedTemplate(), is(equalTo("pink-purple-")));
     }
 }

--- a/jtwig-core/src/test/resources/templates/acceptance/include/include-only.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/include/include-only.twig
@@ -1,0 +1,1 @@
+{% include "included.twig" only %}

--- a/jtwig-core/src/test/resources/templates/acceptance/include/include-with-only.twig
+++ b/jtwig-core/src/test/resources/templates/acceptance/include/include-with-only.twig
@@ -1,0 +1,1 @@
+{% include "included.twig" with {'variable': variable } only %}-{% include "included.twig" with {'variable': 'purple' } only %}-{% include "included.twig" with {'unrelated': 'blue'} only %}


### PR DESCRIPTION
Nothing special to report. Supports `include-only` and `include-with-only` syntax. We must make sure that once we've merged both this and #230 that Jtwig supports `include` [`ignore-missing`][`with`][`only`] syntax as specified in http://twig.sensiolabs.org/doc/tags/include.html
