### PR TITLE
Pursuant to #267, arrays passed to a loop are now evaluated properly

### DIFF
--- a/jtwig-core/src/main/java/org/jtwig/content/model/compilable/For.java
+++ b/jtwig-core/src/main/java/org/jtwig/content/model/compilable/For.java
@@ -14,6 +14,7 @@
 
 package org.jtwig.content.model.compilable;
 
+import java.util.ArrayList;
 import org.jtwig.compile.CompileContext;
 import org.jtwig.content.api.Renderable;
 import org.jtwig.exception.CalculateException;
@@ -27,6 +28,8 @@ import org.jtwig.types.Undefined;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import org.apache.commons.lang3.ArrayUtils;
+import org.jtwig.util.ArrayUtil;
 
 public class For extends Content<For> {
     private final String key;
@@ -90,7 +93,7 @@ public class For extends Content<For> {
                 }
                 
                 if(resolved.getClass().isArray()) {
-                    resolved = Arrays.asList(((Object[])resolved));
+                    resolved = Arrays.asList(ArrayUtil.toArray(resolved));
                 }
                 if(resolved instanceof Map) {
                     handleMap((Map)resolved, context);

--- a/jtwig-core/src/main/java/org/jtwig/content/model/compilable/For.java
+++ b/jtwig-core/src/main/java/org/jtwig/content/model/compilable/For.java
@@ -90,7 +90,7 @@ public class For extends Content<For> {
                 }
                 
                 if(resolved.getClass().isArray()) {
-                    resolved = Arrays.asList(resolved);
+                    resolved = Arrays.asList(((Object[])resolved));
                 }
                 if(resolved instanceof Map) {
                     handleMap((Map)resolved, context);

--- a/jtwig-core/src/main/java/org/jtwig/util/ArrayUtil.java
+++ b/jtwig-core/src/main/java/org/jtwig/util/ArrayUtil.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jtwig.util;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+public class ArrayUtil {
+    public static Byte[] toArray(byte[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Short[] toArray(short[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Integer[] toArray(int[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Long[] toArray(long[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Boolean[] toArray(boolean[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Character[] toArray(char[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Float[] toArray(float[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Double[] toArray(double[] arr) {
+        return ArrayUtils.toObject(arr);
+    }
+    public static Object[] toArray(Object[] arr) {
+        return arr;
+    }
+    public static Object[] toArray(Object obj) {
+        if (!obj.getClass().isArray()) {
+            throw new IllegalArgumentException("Argument is not an array");
+        }
+        
+        Class<?> type = obj.getClass().getComponentType();
+        if (!type.isPrimitive()) {
+            return (Object[])obj;
+        }
+        
+        
+        if (Byte.TYPE.isAssignableFrom(type)) {
+            return toArray((byte[])obj);
+        }
+        if (Short.TYPE.isAssignableFrom(type)) {
+            return toArray((short[])obj);
+        }
+        if (Integer.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((int[])obj);
+        }
+        if (Long.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((long[])obj);
+        }
+        if (Boolean.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((boolean[])obj);
+        }
+        if (Character.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((char[])obj);
+        }
+        if (Float.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((float[])obj);
+        }
+        if (Double.TYPE.isAssignableFrom(obj.getClass().getComponentType())) {
+            return toArray((double[])obj);
+        }
+        
+        throw new IllegalArgumentException("Unsupported argument type: "+type.getName());
+    }
+}

--- a/jtwig-core/src/test/java/org/jtwig/AbstractJtwigTest.java
+++ b/jtwig-core/src/test/java/org/jtwig/AbstractJtwigTest.java
@@ -34,6 +34,10 @@ public abstract class AbstractJtwigTest {
     protected Loader.Resource resource;
     protected OutputStream output;
     
+    enum E {
+        A,B,C
+    }
+    
     @Before
     public void before() throws Exception {
         output = new ByteArrayOutputStream();

--- a/jtwig-core/src/test/java/org/jtwig/AbstractJtwigTest.java
+++ b/jtwig-core/src/test/java/org/jtwig/AbstractJtwigTest.java
@@ -34,10 +34,6 @@ public abstract class AbstractJtwigTest {
     protected Loader.Resource resource;
     protected OutputStream output;
     
-    enum E {
-        A,B,C
-    }
-    
     @Before
     public void before() throws Exception {
         output = new ByteArrayOutputStream();

--- a/jtwig-core/src/test/java/org/jtwig/acceptance/ForExpressionTest.java
+++ b/jtwig-core/src/test/java/org/jtwig/acceptance/ForExpressionTest.java
@@ -111,6 +111,13 @@ public class ForExpressionTest extends AbstractJtwigTest {
         assertThat(theResult(), is("bcdefghijkl"));
     }
     
+    @Test
+    public void iterateOnEnumArray () throws Exception {
+        model.withModelAttribute("values", TestEnum.values());
+        withResource("{% for v in values %}{{ v }}{% endfor %}");
+        assertThat(theResult(), is("ABC"));
+    }
+    
     public static class Obj {
         private final List<String> list = new ArrayList<String>(){{
             add("a");
@@ -120,5 +127,8 @@ public class ForExpressionTest extends AbstractJtwigTest {
         public List<String> getList(String name) {
             return list;
         }
+    }
+    enum TestEnum {
+        A, B, C
     }
 }


### PR DESCRIPTION
Arrays, not collections, were previously evaluated as a single item, rather than a set of items. This nice little code hack fixes that.