### PR TITLE
Fix object comparison compatibility issue.

### DIFF
--- a/jtwig-core/src/main/java/org/jtwig/util/MathOperations.java
+++ b/jtwig-core/src/main/java/org/jtwig/util/MathOperations.java
@@ -65,4 +65,8 @@ public class MathOperations {
 
         return true;
     }
+    
+    public static boolean isNumeric(Object o) {
+        return o instanceof Number;
+    }
 }

--- a/jtwig-core/src/main/java/org/jtwig/util/RelationalOperations.java
+++ b/jtwig-core/src/main/java/org/jtwig/util/RelationalOperations.java
@@ -14,28 +14,53 @@
 
 package org.jtwig.util;
 
+import org.apache.commons.lang3.ObjectUtils;
 import static org.jtwig.util.MathOperations.*;
 
 public class RelationalOperations {
     public static boolean gt (Object a, Object b) {
-        if (areDouble(a, b))
+        if (isNumeric(a) && isNumeric(b)) {
             return toDouble(a) > toDouble(b);
-        return toInt(a) > toInt(b);
+        }
+        if ((a.getClass().isAssignableFrom(b.getClass())
+                || b.getClass().isAssignableFrom(a.getClass()))
+                && a instanceof Comparable && b instanceof Comparable) {
+            return ObjectUtils.compare((Comparable)a, (Comparable)b) > 0;
+        }
+        return false;
     }
     public static boolean gte (Object a, Object b) {
-        if (areDouble(a, b))
+        if (isNumeric(a) && isNumeric(b)) {
             return toDouble(a) >= toDouble(b);
-        return toInt(a) >= toInt(b);
+        }
+        if ((a.getClass().isAssignableFrom(b.getClass())
+                || b.getClass().isAssignableFrom(a.getClass()))
+                && a instanceof Comparable && b instanceof Comparable) {
+            return ObjectUtils.compare((Comparable)a, (Comparable)b) >= 0;
+        }
+        return false;
     }
     public static boolean lt (Object a, Object b) {
-        if (areDouble(a, b))
+        if (isNumeric(a) && isNumeric(b)) {
             return toDouble(a) < toDouble(b);
-        return toInt(a) < toInt(b);
+        }
+        if ((a.getClass().isAssignableFrom(b.getClass())
+                || b.getClass().isAssignableFrom(a.getClass()))
+                && a instanceof Comparable && b instanceof Comparable) {
+            return ObjectUtils.compare((Comparable)a, (Comparable)b) < 0;
+        }
+        return false;
     }
     public static boolean lte (Object a, Object b) {
-        if (areDouble(a, b))
+        if (isNumeric(a) && isNumeric(b)) {
             return toDouble(a) <= toDouble(b);
-        return toInt(a) <= toInt(b);
+        }
+        if ((a.getClass().isAssignableFrom(b.getClass())
+                || b.getClass().isAssignableFrom(a.getClass()))
+                && a instanceof Comparable && b instanceof Comparable) {
+            return ObjectUtils.compare((Comparable)a, (Comparable)b) <= 0;
+        }
+        return false;
     }
 
     public static boolean eq (Object a, Object b) {

--- a/jtwig-core/src/test/java/org/jtwig/acceptance/BinaryBooleanOperatorTest.java
+++ b/jtwig-core/src/test/java/org/jtwig/acceptance/BinaryBooleanOperatorTest.java
@@ -107,11 +107,39 @@ public class BinaryBooleanOperatorTest extends AbstractJtwigTest {
     public void lessOrEqualTo () throws Exception {
         withResource("{% if (2 <= 2) %}Hi{% endif %}");
         assertThat(theResult(), is("Hi"));
+        // Strings?
+        withResource("{% if (\"test1\" <= \"test2\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (\"test2\" <= \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (\"test1\" <= \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        // Dates?
+        withResource("{% if (date('2014-12-12') <= date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (date('2015-01-01') <= date('2014-12-12')) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (date('2015-01-01') <= date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
     }
 
     @Test
     public void lessThan () throws Exception {
         withResource("{% if (2 < 2) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        // Strings?
+        withResource("{% if (\"test1\" < \"test2\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (\"test2\" < \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (\"test1\" < \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        // Dates?
+        withResource("{% if (date('2014-12-12') < date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (date('2015-01-01') < date('2014-12-12')) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (date('2015-01-01') < date('2015-01-01')) %}Hi{% endif %}");
         assertThat(theResult(), is(""));
     }
 
@@ -119,11 +147,39 @@ public class BinaryBooleanOperatorTest extends AbstractJtwigTest {
     public void greaterThan () throws Exception {
         withResource("{% if (2 > 2) %}Hi{% endif %}");
         assertThat(theResult(), is(""));
+        // Strings?
+        withResource("{% if (\"test1\" > \"test2\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (\"test2\" > \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (\"test1\" > \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        // Dates?
+        withResource("{% if (date('2014-12-12') > date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (date('2015-01-01') > date('2014-12-12')) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (date('2015-01-01') > date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
     }
 
     @Test
     public void greaterOrEqualThan () throws Exception {
         withResource("{% if (2 >= 2) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        // Strings?
+        withResource("{% if (\"test1\" >= \"test2\") %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (\"test2\" >= \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (\"test1\" >= \"test1\") %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        // Dates?
+        withResource("{% if (date('2014-12-12') >= date('2015-01-01')) %}Hi{% endif %}");
+        assertThat(theResult(), is(""));
+        withResource("{% if (date('2015-01-01') >= date('2014-12-12')) %}Hi{% endif %}");
+        assertThat(theResult(), is("Hi"));
+        withResource("{% if (date('2015-01-01') >= date('2015-01-01')) %}Hi{% endif %}");
         assertThat(theResult(), is("Hi"));
     }
 


### PR DESCRIPTION
Pursuant to #258, fixed a Twig compatibility issue where dates, strings, and other non-primitive and non-primitive-wrappers could not be compared