### PR TITLE
Update to Servlet API Spec 3.1.0

### DIFF
--- a/jtwig-spring/pom.xml
+++ b/jtwig-spring/pom.xml
@@ -26,7 +26,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/jtwig-spring/pom.xml
+++ b/jtwig-spring/pom.xml
@@ -10,6 +10,10 @@
     <artifactId>jtwig-spring</artifactId>
     <name>Jtwig Spring</name>
 
+    <properties>
+        <jetty.version>9.1.3.v20140225</jetty.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.lyncode</groupId>
@@ -62,13 +66,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.1.3.v20140225</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.1.3.v20140225</version>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletRequest.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletRequest.java
@@ -14,25 +14,23 @@
 
 package com.lyncode.jtwig.util.render;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.parboiled.common.StringUtils;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+import static com.lyncode.jtwig.util.FilePath.path;
+import static com.lyncode.jtwig.util.ObjectSnapshot.snapshot;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import java.io.*;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.security.Principal;
 import java.util.*;
 
-import static com.lyncode.jtwig.util.FilePath.path;
-import static com.lyncode.jtwig.util.ObjectSnapshot.snapshot;
+import javax.servlet.*;
+import javax.servlet.http.*;
+
+import org.parboiled.common.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 
 public class RenderHttpServletRequest implements HttpServletRequest {
     private static Logger LOG = LoggerFactory.getLogger(RenderHttpServletRequest.class);
@@ -208,7 +206,7 @@ public class RenderHttpServletRequest implements HttpServletRequest {
         else
             values = postParameters.get(name);
 
-        return values.isEmpty() ? null : values.get(0);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
     }
 
     @Override
@@ -342,7 +340,27 @@ public class RenderHttpServletRequest implements HttpServletRequest {
         return isRequestedSessionIdFromURL();
     }
 
-    @Override
+	@Override public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+		return this.initialValues.authenticate(response);
+	}
+
+	@Override public void login(String username, String password) throws ServletException {
+		this.initialValues.login(username, password);
+	}
+
+	@Override public void logout() throws ServletException {
+		this.initialValues.logout();
+	}
+
+	@Override public Collection<Part> getParts() throws IOException, ServletException {
+		return this.initialValues.getParts();
+	}
+
+	@Override public Part getPart(String name) throws IOException, ServletException {
+		return this.initialValues.getPart(name);
+	}
+
+	@Override
     public String getCharacterEncoding() {
         return initialValues.getCharacterEncoding();
     }
@@ -428,7 +446,35 @@ public class RenderHttpServletRequest implements HttpServletRequest {
         return initialValues.getLocalPort();
     }
 
-    private String encode(String value) {
+	@Override public ServletContext getServletContext() {
+		return this.initialValues.getServletContext();
+	}
+
+	@Override public AsyncContext startAsync() throws IllegalStateException {
+		return this.initialValues.startAsync();
+	}
+
+	@Override public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+		return null;
+	}
+
+	@Override public boolean isAsyncStarted() {
+		return this.initialValues.isAsyncStarted();
+	}
+
+	@Override public boolean isAsyncSupported() {
+		return this.initialValues.isAsyncSupported();
+	}
+
+	@Override public AsyncContext getAsyncContext() {
+		return this.initialValues.getAsyncContext();
+	}
+
+	@Override public DispatcherType getDispatcherType() {
+		return this.initialValues.getDispatcherType();
+	}
+
+	private String encode(String value) {
         String encoding = Charset.defaultCharset().displayName();
         try {
             return URLEncoder.encode(value, encoding);

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletResponse.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletResponse.java
@@ -14,17 +14,19 @@
 
 package com.lyncode.jtwig.util.render;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.Locale;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RenderHttpServletResponse implements HttpServletResponse {
     private static Logger LOG = LoggerFactory.getLogger(RenderHttpServletResponse.class);
@@ -136,7 +138,27 @@ public class RenderHttpServletResponse implements HttpServletResponse {
         LOG.debug("You can't set the status when including. Only the main request can do that!");
     }
 
-    @Override
+	@Override public int getStatus() {
+		LOG.debug("Operation not supported on embed content");
+		return 0;
+	}
+
+	@Override public String getHeader(String name) {
+		LOG.debug("Operation not supported on embed content");
+		return null;
+	}
+
+	@Override public Collection<String> getHeaders(String name) {
+		LOG.debug("Operation not supported on embed content");
+		return null;
+	}
+
+	@Override public Collection<String> getHeaderNames() {
+		LOG.debug("Operation not supported on embed content");
+		return null;
+	}
+
+	@Override
     public String getCharacterEncoding() {
         LOG.debug("Operation not supported on embed content");
         return null;

--- a/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletResponse.java
+++ b/jtwig-spring/src/main/java/com/lyncode/jtwig/util/render/RenderHttpServletResponse.java
@@ -14,6 +14,13 @@
 
 package com.lyncode.jtwig.util.render;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -21,21 +28,27 @@ import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Locale;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class RenderHttpServletResponse implements HttpServletResponse {
     private static Logger LOG = LoggerFactory.getLogger(RenderHttpServletResponse.class);
 
     private int contentLength = 0;
+    private long contentLengthLong = 0;
     private OutputStream output = new ByteArrayOutputStream();
     private PrintWriter writer = new PrintWriter(output);
 
     private ServletOutputStream outputStream = new ServletOutputStream() {
+        private WriteListener writeListener;
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            this.writeListener = writeListener;
+        }
+
         @Override
         public void write(int b) throws IOException {
             output.write(b);
@@ -188,6 +201,11 @@ public class RenderHttpServletResponse implements HttpServletResponse {
     @Override
     public void setContentLength(int len) {
         this.contentLength = len;
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+        this.contentLengthLong = len;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.9.5</mockito.version>
         <junit.version>4.11</junit.version>
-        <servlet-api.version>2.5</servlet-api.version>
+        <servlet-api.version>3.0.1</servlet-api.version>
         <slf4j.version>1.7.7</slf4j.version>
         <commons.lang3.version>3.1</commons.lang3.version>
         <jackson.version>1.9.13</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.9.5</mockito.version>
         <junit.version>4.11</junit.version>
-        <servlet-api.version>3.0.1</servlet-api.version>
+        <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.7</slf4j.version>
         <commons.lang3.version>3.1</commons.lang3.version>
         <jackson.version>1.9.13</jackson.version>


### PR DESCRIPTION
Proposed fix for issue https://github.com/jtwig/jtwig/issues/284
Somes of the added methods may be poorly implemented but as they are used for async requests/responses, they seem to no use in the Spring render function case.
Some tests fail on my workstation (Windows/IDEA IntelliJ) but no new ones compared to previous revision. CI seems OK though.
Changelog:
- Updated Servlet API Spec to 3.1.0
- Added missing methods in RenderHttpServletRequest and RenderHttpServletResponse
- Added a control over values before isEmpty in RenderHttpServletRequest::getParameter
