### PR TITLE
Extract static methods when passing a class (not an object) parameter

### DIFF
--- a/jtwig-core/src/main/java/com/lyncode/jtwig/util/ObjectExtractor.java
+++ b/jtwig-core/src/main/java/com/lyncode/jtwig/util/ObjectExtractor.java
@@ -118,10 +118,12 @@ public class ObjectExtractor {
                         "has"
                 };
 
-                Set<Method> methods = getAllMethods(context.getClass(), methodMatcher(equalToIgnoringCase(name), args.length));
+	            Class clazz = context instanceof Class ? (Class) context  : context.getClass();
+
+                Set<Method> methods = getAllMethods(clazz, methodMatcher(equalToIgnoringCase(name), args.length));
                 int i = 0;
                 while (methods.isEmpty() && i < prefixes.length) {
-                    methods = getAllMethods(context.getClass(), methodMatcher(equalToIgnoringCase(prefixes[i++] + name), args.length));
+                    methods = getAllMethods(clazz, methodMatcher(equalToIgnoringCase(prefixes[i++] + name), args.length));
                 }
 
                 if (methods.isEmpty()) return new Result<Object>();

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/util/ObjectExtractorTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/util/ObjectExtractorTest.java
@@ -14,49 +14,44 @@
 
 package com.lyncode.jtwig.util;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ObjectExtractorTest
-{
-	@Test
-	public void shouldExtractFromMap() throws ObjectExtractor.ExtractException
-	{
-		Map<String, Object> map = new HashMap<String, Object>();
-		map.put("key", "value");
-		ObjectExtractor underTest = new ObjectExtractor(map);
+public class ObjectExtractorTest {
+    @Test
+    public void shouldExtractFromMap () throws ObjectExtractor.ExtractException {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("key", "value");
+        ObjectExtractor underTest = new ObjectExtractor(map);
 
-		assertThat(underTest.extract("key"), is((Object) "value"));
-	}
+        assertThat(underTest.extract("key"), is((Object) "value"));
+    }
 
-	@Test
-	public void shouldExtractFromInheritedMethod() throws ObjectExtractor.ExtractException
-	{
-		List<String> list = new ArrayList<String>();
-		ObjectExtractor underTest = new ObjectExtractor(list);
+    @Test
+    public void shouldExtractFromInheritedMethod () throws ObjectExtractor.ExtractException {
+        List<String> list = new ArrayList<String>();
+        ObjectExtractor underTest = new ObjectExtractor(list);
 
-		assertThat(underTest.extract("tostring"), is(notNullValue()));
-	}
+        assertThat(underTest.extract("tostring"), is(notNullValue()));
+    }
+    @Test
+    public void shouldExtractFromInheritedField () throws ObjectExtractor.ExtractException {
+        B b = new B();
+        b.a = "a";
+        b.b = "b";
+        ObjectExtractor underTest = new ObjectExtractor(b);
 
-	@Test
-	public void shouldExtractFromInheritedField() throws ObjectExtractor.ExtractException
-	{
-		B b = new B();
-		b.a = "a";
-		b.b = "b";
-		ObjectExtractor underTest = new ObjectExtractor(b);
-
-		assertThat(underTest.extract("a"), is((Object) "a"));
-		assertThat(underTest.extract("b"), is((Object) "b"));
-	}
+        assertThat(underTest.extract("a"), is((Object) "a"));
+        assertThat(underTest.extract("b"), is((Object) "b"));
+    }
 
 	@Test
 	public void shouldExtractFromStaticMethod() throws ObjectExtractor.ExtractException
@@ -66,13 +61,11 @@ public class ObjectExtractorTest
 		assertThat(underTest.extract("valueOf", 123), is((Object) "123"));
 	}
 
-	private static class A
-	{
-		public String	a;
-	}
+	private static class A {
+        public String a;
+    }
 
-	private static class B extends A
-	{
-		public String	b;
-	}
+    private static class B extends A {
+        public String b;
+    }
 }

--- a/jtwig-core/src/test/java/com/lyncode/jtwig/util/ObjectExtractorTest.java
+++ b/jtwig-core/src/test/java/com/lyncode/jtwig/util/ObjectExtractorTest.java
@@ -14,50 +14,65 @@
 
 package com.lyncode.jtwig.util;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
-public class ObjectExtractorTest {
-    @Test
-    public void shouldExtractFromMap () throws ObjectExtractor.ExtractException {
-        Map<String, Object> map = new HashMap<String, Object>();
-        map.put("key", "value");
-        ObjectExtractor underTest = new ObjectExtractor(map);
+public class ObjectExtractorTest
+{
+	@Test
+	public void shouldExtractFromMap() throws ObjectExtractor.ExtractException
+	{
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("key", "value");
+		ObjectExtractor underTest = new ObjectExtractor(map);
 
-        assertThat(underTest.extract("key"), is((Object) "value"));
-    }
+		assertThat(underTest.extract("key"), is((Object) "value"));
+	}
 
-    @Test
-    public void shouldExtractFromInheritedMethod () throws ObjectExtractor.ExtractException {
-        List<String> list = new ArrayList<String>();
-        ObjectExtractor underTest = new ObjectExtractor(list);
+	@Test
+	public void shouldExtractFromInheritedMethod() throws ObjectExtractor.ExtractException
+	{
+		List<String> list = new ArrayList<String>();
+		ObjectExtractor underTest = new ObjectExtractor(list);
 
-        assertThat(underTest.extract("tostring"), is(notNullValue()));
-    }
-    @Test
-    public void shouldExtractFromInheritedField () throws ObjectExtractor.ExtractException {
-        B b = new B();
-        b.a = "a";
-        b.b = "b";
-        ObjectExtractor underTest = new ObjectExtractor(b);
+		assertThat(underTest.extract("tostring"), is(notNullValue()));
+	}
 
-        assertThat(underTest.extract("a"), is((Object) "a"));
-        assertThat(underTest.extract("b"), is((Object) "b"));
-    }
+	@Test
+	public void shouldExtractFromInheritedField() throws ObjectExtractor.ExtractException
+	{
+		B b = new B();
+		b.a = "a";
+		b.b = "b";
+		ObjectExtractor underTest = new ObjectExtractor(b);
 
-    private static class A {
-        public String a;
-    }
+		assertThat(underTest.extract("a"), is((Object) "a"));
+		assertThat(underTest.extract("b"), is((Object) "b"));
+	}
 
-    private static class B extends A {
-        public String b;
-    }
+	@Test
+	public void shouldExtractFromStaticMethod() throws ObjectExtractor.ExtractException
+	{
+		ObjectExtractor underTest = new ObjectExtractor(String.class);
+
+		assertThat(underTest.extract("valueOf", 123), is((Object) "123"));
+	}
+
+	private static class A
+	{
+		public String	a;
+	}
+
+	private static class B extends A
+	{
+		public String	b;
+	}
 }


### PR DESCRIPTION
Hi there!

I noticed it was not possible to use classes as parameters (e.g. pass String.class to invoke valueOf() in a template).

A simple fix for the described issue is PRed ;)